### PR TITLE
adds retries and a threadpool

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ install_requirements = [
     "pyswagger >= 0.8.27",
     "six",
     "pytz",
+    "futures",
 ]
 
 # test requirements

--- a/test/mock.py
+++ b/test/mock.py
@@ -207,6 +207,25 @@ def public_incursion_warning(url, request):
     )
 
 
+@httmock.urlmatch(
+    scheme="https",
+    netloc=r"esi\.tech\.ccp\.is$",
+    path=r"^/latest/incursions/$"
+)
+def public_incursion_server_error(url, request):
+    """ Mock endpoint for incursion.
+    Public endpoint without cache
+    """
+    public_incursion_server_error.count += 1
+    return httmock.response(
+        status_code=500,
+        content={            
+            "error": "broke",
+            "count": public_incursion_server_error.count
+        }
+    )
+public_incursion_server_error.count = 0
+
 _all_auth_mock_ = [
     oauth_token,
     oauth_verify,

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -194,6 +194,18 @@ class TestEsiPy(unittest.TestCase):
             incursions = self.client_no_auth.request(operation)
             self.assertEqual(incursions.data[0].faction_id, 500019)
 
+    def test_esipy_multi_request(self): 
+        operation = self.app.op['get_incursions']()
+
+        with httmock.HTTMock(public_incursion):
+            count = 0
+            for req, incursions in self.client_no_auth.multi_request([operation,operation,operation], threads=2):
+                self.assertEqual(incursions.data[0].faction_id, 500019)
+                count += 1
+            
+            # Check we made 3 requests
+            self.assertEqual(count, 3)
+
     def test_esipy_backoff(self): 
         operation = self.app.op['get_incursions']()
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -199,7 +199,8 @@ class TestEsiPy(unittest.TestCase):
 
         with httmock.HTTMock(public_incursion):
             count = 0
-            for req, incursions in self.client_no_auth.multi_request([operation,operation,operation], threads=2):
+            for req, incursions in self.client_no_auth.multi_request(
+                    [operation, operation, operation], threads=2):
                 self.assertEqual(incursions.data[0].faction_id, 500019)
                 count += 1
             

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -194,7 +194,7 @@ class TestEsiPy(unittest.TestCase):
             incursions = self.client_no_auth.request(operation)
             self.assertEqual(incursions.data[0].faction_id, 500019)
 
-    def test_esipy_multi_request(self): 
+    def test_esipy_multi_request(self):
         operation = self.app.op['get_incursions']()
 
         with httmock.HTTMock(public_incursion):
@@ -203,11 +203,11 @@ class TestEsiPy(unittest.TestCase):
                     [operation, operation, operation], threads=2):
                 self.assertEqual(incursions.data[0].faction_id, 500019)
                 count += 1
-            
+
             # Check we made 3 requests
             self.assertEqual(count, 3)
 
-    def test_esipy_backoff(self): 
+    def test_esipy_backoff(self):
         operation = self.app.op['get_incursions']()
 
         start_calls = time.time()
@@ -217,7 +217,7 @@ class TestEsiPy(unittest.TestCase):
             self.assertEqual(incursions.data.error, 'broke')
 
         end_calls = time.time()
-  
+
         # Check we retried 5 times
         self.assertEqual(incursions.data.count, 5)
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -6,6 +6,7 @@ from .mock import public_incursion
 from .mock import public_incursion_no_expires
 from .mock import public_incursion_no_expires_second
 from .mock import public_incursion_warning
+from .mock import public_incursion_server_error
 from esipy import App
 from esipy import EsiClient
 from esipy import EsiSecurity
@@ -17,6 +18,7 @@ from requests.adapters import HTTPAdapter
 
 import httmock
 import mock
+import time
 import six
 import unittest
 import warnings
@@ -55,7 +57,7 @@ class TestEsiPy(unittest.TestCase):
 
         self.cache = DictCache()
         self.client = EsiClient(self.security, cache=self.cache)
-        self.client_no_auth = EsiClient(cache=self.cache)
+        self.client_no_auth = EsiClient(cache=self.cache, retry_requests=True)
 
     def tearDown(self):
         """ clear the cache so we don't have residual data """
@@ -191,3 +193,20 @@ class TestEsiPy(unittest.TestCase):
             # this shouldn't create any errors
             incursions = self.client_no_auth.request(operation)
             self.assertEqual(incursions.data[0].faction_id, 500019)
+
+    def test_esipy_backoff(self): 
+        operation = self.app.op['get_incursions']()
+
+        start_calls = time.time()
+
+        with httmock.HTTMock(public_incursion_server_error):
+            incursions = self.client_no_auth.request(operation)
+            self.assertEqual(incursions.data.error, 'broke')
+
+        end_calls = time.time()
+  
+        # Check we retried 5 times
+        self.assertEqual(incursions.data.count, 5)
+
+        # Check that backoff slept for a sum > 2 seconds
+        self.assertTrue(end_calls - start_calls > 2)


### PR DESCRIPTION
hey,

figured both of these will end up in people's codebases all over the place, so maybe better to implement this here.

here's a little example script of the new functionality:

```
import time

from esipy import App
from esipy import EsiClient


def main():
    start = time.time()

    esi = App.create("https://esi.tech.ccp.is/latest/swagger.json")
    client = EsiClient(retry_requests=True)
    types = client.request(esi.op["get_universe_types"]())
    print("types: {}".format(types.status))

    for req, res in client.multi_request(
        [esi.op["get_universe_types_type_id"](type_id=x) for x in types.data],
        threads=20,
    ):
        print("{} => {!r}".format(req.path, res.data))

    print("finished all types in {:.2f}s".format(time.time() - start))


if __name__ == "__main__":
    main()
```