### PR TITLE
Fix for issue #22 Make no attempt to cache when no expires header.

### DIFF
--- a/esipy/client.py
+++ b/esipy/client.py
@@ -284,10 +284,6 @@ class EsiClient(BaseClient):
                 cache_timeout,
             )
 
-        else:
-            # no expires header so we won't cache the call
-            pass
-
     def __make_cache_key(self, request):
         headers = frozenset(request._p['header'].items())
         path = frozenset(request._p['path'].items())

--- a/esipy/client.py
+++ b/esipy/client.py
@@ -33,7 +33,6 @@ CachedResponse = namedtuple(
 
 
 class EsiClient(BaseClient):
-
     __schemes__ = set(['https'])
 
     __image_server__ = {
@@ -274,21 +273,20 @@ class EsiClient(BaseClient):
             now = (datetime.utcnow() - epoch).total_seconds()
             cache_timeout = int(expire) - int(now)
 
-        else:
-            # if no expire, define that there is no cache
-            # -1 will be now -1sec, so it'll expire
-            cache_timeout = -1
+            self.cache.set(
+                cache_key,
+                CachedResponse(
+                    status_code=res.status_code,
+                    headers=res.headers,
+                    content=res.content,
+                    url=res.url,
+                ),
+                cache_timeout,
+            )
 
-        self.cache.set(
-            cache_key,
-            CachedResponse(
-                status_code=res.status_code,
-                headers=res.headers,
-                content=res.content,
-                url=res.url,
-            ),
-            cache_timeout,
-        )
+        else:
+            # no expires header so we won't cache the call
+            pass
 
     def __make_cache_key(self, request):
         headers = frozenset(request._p['header'].items())


### PR DESCRIPTION
(#22) Instead of using a magic number just don't attempt to cache the data when there is no expire time. This avoids an error in redis version 4.0.1 at least where a timeout value of -1 for setex barfs.