### PR TITLE
Added fix for case where CCP swagger returns result with outdate Expires: header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
 
 script:
   - flake8 esipy
+  - flake8 test
   - coverage run setup.py test
 
 after_success: coveralls

--- a/esipy/client.py
+++ b/esipy/client.py
@@ -269,7 +269,8 @@ class EsiClient(BaseClient):
             now = (datetime.utcnow() - epoch).total_seconds()
             cache_timeout = int(expire) - int(now)
 
-            # Occasionally CCP swagger will return an outdated expire - warn and skip cache
+            # Occasionally CCP swagger will return an outdated expire
+            # - warn and skip cache
             if cache_timeout > 0:
                 self.cache.set(
                     cache_key,
@@ -282,6 +283,7 @@ class EsiClient(BaseClient):
                     cache_timeout,
                 )
             else:
-                LOGGER.warning("[%s] returned expired result: %s", res.url, res.headers)
+                LOGGER.warning(
+                    "[%s] returned expired result: %s", res.url,
+                    res.headers)
                 warnings.warn("[%s] returned expired result" % res.url)
-

--- a/esipy/client.py
+++ b/esipy/client.py
@@ -269,13 +269,19 @@ class EsiClient(BaseClient):
             now = (datetime.utcnow() - epoch).total_seconds()
             cache_timeout = int(expire) - int(now)
 
-            self.cache.set(
-                cache_key,
-                CachedResponse(
-                    status_code=res.status_code,
-                    headers=res.headers,
-                    content=res.content,
-                    url=res.url,
-                ),
-                cache_timeout,
-            )
+            # Occasionally CCP swagger will return an outdated expire - warn and skip cache
+            if cache_timeout > 0:
+                self.cache.set(
+                    cache_key,
+                    CachedResponse(
+                        status_code=res.status_code,
+                        headers=res.headers,
+                        content=res.content,
+                        url=res.url,
+                    ),
+                    cache_timeout,
+                )
+            else:
+                LOGGER.warning("[%s] returned expired result: %s", res.url, res.headers)
+                warnings.warn("[%s] returned expired result" % res.url)
+

--- a/test/mock.py
+++ b/test/mock.py
@@ -15,6 +15,15 @@ def make_expire_time_str():
     return date.strftime('%a, %d %b %Y %H:%M:%S GMT')
 
 
+def make_expired_time_str():
+    """ Generate an expired date string for the Expires header
+    RFC 7231 format (always GMT datetime).
+    """
+    date = datetime.datetime.utcnow()
+    date -= datetime.timedelta(days=1)
+    return date.strftime('%a, %d %b %Y %H:%M:%S GMT')
+
+
 @httmock.urlmatch(
     scheme="https",
     netloc=r"login\.eveonline\.com$",
@@ -228,6 +237,36 @@ def public_incursion_server_error(url, request):
 
 
 public_incursion_server_error.count = 0
+
+
+@httmock.urlmatch(
+    scheme="https",
+    netloc=r"esi\.tech\.ccp\.is$",
+    path=r"^/latest/incursions/$"
+)
+def public_incursion_expired(url, request):
+    """ Mock endpoint for incursion.
+    Public endpoint returning Expires value in the past
+    """
+    return httmock.response(
+        headers={'Expires': make_expired_time_str()},
+        status_code=200,
+        content=[
+            {
+                "type": "Incursion",
+                "state": "mobilizing",
+                "staging_solar_system_id": 30003893,
+                "constellation_id": 20000568,
+                "infested_solar_systems": [
+                    30003888,
+                ],
+                "has_boss": True,
+                "faction_id": 500019,
+                "influence": 1
+            }
+        ]
+    )
+
 
 _all_auth_mock_ = [
     oauth_token,

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -248,15 +248,10 @@ class TestEsiPy(unittest.TestCase):
         self.assertEqual(send_function.count, 5)
 
     def test_esipy_expired_response(self):
-        operation = self.app.op['get_incursions']()
+        operation = self.app.op['get_incursions']
 
         with httmock.HTTMock(public_incursion_expired):
-            warnings.simplefilter('ignore')
-            incursions = self.client_no_auth.request(operation)
-            self.assertEqual(incursions.status, 200)
-
-            warnings.resetwarnings()
             warnings.filterwarnings('error', '.*returned expired result')
 
             with self.assertRaises(UserWarning):
-                incursions = self.client_no_auth.request(operation)
+                self.client_no_auth.request(operation())

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -255,3 +255,8 @@ class TestEsiPy(unittest.TestCase):
 
             with self.assertRaises(UserWarning):
                 self.client_no_auth.request(operation())
+
+            warnings.resetwarnings()
+            warnings.simplefilter('ignore')
+            incursions = self.client_no_auth.request(operation())
+            self.assertEquals(incursions.status, 200)

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -8,6 +8,7 @@ from .mock import public_incursion_no_expires
 from .mock import public_incursion_no_expires_second
 from .mock import public_incursion_server_error
 from .mock import public_incursion_warning
+from .mock import public_incursion_expired
 from esipy import App
 from esipy import EsiClient
 from esipy import EsiSecurity
@@ -245,3 +246,16 @@ class TestEsiPy(unittest.TestCase):
 
         self.assertEqual(incursions.status, 500)
         self.assertEqual(send_function.count, 5)
+
+    def test_esipy_expired_response(self):
+        operation = self.app.op['get_incursions']()
+
+        with httmock.HTTMock(public_incursion_expired):
+            warnings.simplefilter('ignore')
+            incursions = self.client_no_auth.request(operation)
+            self.assertEqual(incursions.status, 200)
+
+            warnings.filterwarnings('error', '.*returned expired result')
+
+            with self.assertRaises(UserWarning):
+                incursions = self.client_no_auth.request(operation)

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -255,6 +255,7 @@ class TestEsiPy(unittest.TestCase):
             incursions = self.client_no_auth.request(operation)
             self.assertEqual(incursions.status, 200)
 
+            warnings.resetwarnings()
             warnings.filterwarnings('error', '.*returned expired result')
 
             with self.assertRaises(UserWarning):


### PR DESCRIPTION
Sometimes the EVE API returns results with an Expiry date set to the past - currently this causes esipy to exception, as the negative value calculated for cache_timeout is passed onto redis which throws an exception.

I'm just adding a check for this case and a few warnings so this can be diagnosed if it occurs.