### PR TITLE
Resolved an issue when using the test SSO server 

### DIFF
--- a/esipy/security.py
+++ b/esipy/security.py
@@ -46,7 +46,7 @@ class EsiSecurity(object):
         app = kwargs.pop('app', None)
         sso_url = kwargs.pop('sso_url', "https://login.eveonline.com")
         esi_url = kwargs.pop('esi_url', "https://esi.tech.ccp.is")
-	esi_datasource = kwargs.pop('esi_datasource', "tranquility")
+        esi_datasource = kwargs.pop('esi_datasource', "tranquility")
 
         self.security_name = kwargs.pop('security_name', 'evesso')
         self.redirect_uri = redirect_uri
@@ -89,7 +89,7 @@ class EsiSecurity(object):
         # use ESI url for verify, since it's better for caching
         if esi_url is None or esi_url == "":
             raise AttributeError("esi_url cannot be None or empty")
-	self.oauth_verify = '%s/verify/?datasource=%s' % (esi_url, esi_datasource)
+        self.oauth_verify = '%s/verify/?datasource=%s' % (esi_url, esi_datasource)
 
         # session request stuff
         self._session = Session()

--- a/esipy/security.py
+++ b/esipy/security.py
@@ -40,10 +40,13 @@ class EsiSecurity(object):
         :param app: (optionnal) the pyswagger app object
         :param security_name: (optionnal) the name of the object holding the
         informations in the securityDefinitions, used to check authed endpoint
+        :param esi_datasource: (optional) The ESI datasource used to validate
+        SSO authentication. Defaults to tranquility
         """
         app = kwargs.pop('app', None)
         sso_url = kwargs.pop('sso_url', "https://login.eveonline.com")
         esi_url = kwargs.pop('esi_url', "https://esi.tech.ccp.is")
+	esi_datasource = kwargs.pop('esi_datasource', "tranquility")
 
         self.security_name = kwargs.pop('security_name', 'evesso')
         self.redirect_uri = redirect_uri
@@ -86,7 +89,7 @@ class EsiSecurity(object):
         # use ESI url for verify, since it's better for caching
         if esi_url is None or esi_url == "":
             raise AttributeError("esi_url cannot be None or empty")
-        self.oauth_verify = '%s/verify/' % esi_url
+	self.oauth_verify = '%s/verify/?datasource=%s' % (esi_url, esi_datasource)
 
         # session request stuff
         self._session = Session()

--- a/esipy/security.py
+++ b/esipy/security.py
@@ -89,7 +89,10 @@ class EsiSecurity(object):
         # use ESI url for verify, since it's better for caching
         if esi_url is None or esi_url == "":
             raise AttributeError("esi_url cannot be None or empty")
-        self.oauth_verify = '%s/verify/?datasource=%s' % (esi_url, esi_datasource)
+        self.oauth_verify = '%s/verify/?datasource=%s' % (
+            esi_url,
+            esi_datasource
+        )
 
         # session request stuff
         self._session = Session()

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -26,7 +26,7 @@ pyswagger_logger.setLevel(logging.ERROR)
 class TestEsiSecurity(unittest.TestCase):
     CALLBACK_URI = "https://foo.bar/baz/callback"
     LOGIN_EVE = "https://login.eveonline.com"
-    OAUTH_VERIFY = "https://esi.tech.ccp.is/verify/"
+    OAUTH_VERIFY = "https://esi.tech.ccp.is/verify/?datasource=tranquility"
     OAUTH_TOKEN = "%s/oauth/token" % LOGIN_EVE
     OAUTH_AUTHORIZE = "%s/oauth/authorize" % LOGIN_EVE
     CLIENT_ID = 'foo'
@@ -114,12 +114,13 @@ class TestEsiSecurity(unittest.TestCase):
             client_id=TestEsiSecurity.CLIENT_ID,
             secret_key=TestEsiSecurity.SECRET_KEY,
             sso_url='foo.com',
-            esi_url='bar.baz'
+            esi_url='bar.baz',
+            esi_datasource='singularity'
         )
 
         self.assertEqual(
             security.oauth_verify,
-            "bar.baz/verify/"
+            "bar.baz/verify/?datasource=singularity"
         )
         self.assertEqual(
             security.oauth_token,


### PR DESCRIPTION
While working on an application that used CCP's test SSO server (login.testeveonline.com). I ran into a problem in the EsiSecurity class when verifying the user's authentication status. The ESI api call to "https://esi.tech.ccp.is/verify" didn't include a datasource parameter, the SSO access token (from CCP's test SSO server) was being compared against the tranquility authentication database, which always rejected it as invalid.