### PR TITLE
Fixes and improvements - 1.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,10 @@ services:
   - redis
 
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 
 install:
   - if [[ `python --version | grep 3.6` ]]; then pip install -U setuptools; fi;

--- a/esipy/__init__.py
+++ b/esipy/__init__.py
@@ -11,4 +11,4 @@ except ImportError:  # pragma: no cover
     # Not installed or in install (not yet installed) so ignore
     pass
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'

--- a/esipy/app.py
+++ b/esipy/app.py
@@ -103,7 +103,8 @@ class EsiApp(object):
         if res.status_code == 304 and cached_app is not None:
             self.cache.set(
                 cache_key,
-                (cached_app, res.headers, timeout)
+                (cached_app, res.headers, timeout),
+                timeout
             )
             return cached_app
 
@@ -132,7 +133,7 @@ class EsiApp(object):
             )
 
         if self.caching and app:
-            self.cache.set(cache_key, (app, res.headers, timeout))
+            self.cache.set(cache_key, (app, res.headers, timeout), timeout)
 
         return app
 

--- a/esipy/client.py
+++ b/esipy/client.py
@@ -54,7 +54,8 @@ class EsiClient(BaseClient):
             signal to use, instead of using the global API_CALL_STATS
         :param timeout: (optional) default value [None=No timeout]
         timeout in seconds for requests
-
+        :param no_etag_body: (optional) default False, set to return empty
+        response when ETag requests return 304 (normal http behavior)
         """
         super(EsiClient, self).__init__(security)
         self.security = security
@@ -104,6 +105,7 @@ class EsiClient(BaseClient):
         )
 
         self.timeout = kwargs.pop('timeout', None)
+        self.no_etag_body = kwargs.pop('no_etag_body', False)
 
     def _retry_request(self, req_and_resp, _retry=0, **kwargs):
         """Uses self._request in a sane retry loop (for 5xx level errors).
@@ -413,7 +415,9 @@ class EsiClient(BaseClient):
 
         # if we have HTTP 304 (content didn't change), return the cached
         # response updated with the new headers
-        if res.status_code == 304 and cached_response is not None:
+        if (res.status_code == 304
+                and cached_response is not None
+                and not self.no_etag_body):
             cached_response.headers['Expires'] = res.headers.get('Expires')
             cached_response.headers['Date'] = res.headers.get('Date')
             return cached_response

--- a/esipy/client.py
+++ b/esipy/client.py
@@ -232,8 +232,8 @@ class EsiClient(BaseClient):
                 raw=six.BytesIO(res.content).getvalue()
             )
 
-        except ValueError:
-            # catch JSONDecodeError/ValueError when response is not JSON
+        except (ValueError, Exception):
+            # catch when response is not JSON
             raise APIException(
                 request.url,
                 res.status_code,
@@ -324,6 +324,7 @@ class EsiClient(BaseClient):
                         content=res.content,
                         url=res.url,
                     ),
+                    cache_timeout
                 )
             else:
                 LOGGER.warning(

--- a/esipy/events.py
+++ b/esipy/events.py
@@ -3,7 +3,6 @@
 to some defined event within EsiPy for the user to be able to do
 specific actions at some times """
 import logging
-import sys
 
 LOGGER = logging.getLogger(__name__)
 
@@ -53,11 +52,11 @@ class Signal(object):
         for receiver in self.event_receivers:
             try:
                 receiver(**kwargs)
-            except Exception as err:  # pylint: disable=W0703
-                if not hasattr(err, '__traceback__'):
-                    LOGGER.error(sys.exc_info()[2])
-                else:
-                    LOGGER.error(getattr(err, '__traceback__'))
+            except Exception:  # pylint: disable=W0703
+                LOGGER.exception(
+                    'Exception while sending to "%s".',
+                    getattr(receiver, '__name__', repr(receiver))
+                )
 
 
 # define required alarms

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
-import esipy
+# -*- encoding: utf-8 -*-
+""" Setup for EsiPy """
 import io
-
 from setuptools import setup
+
+import esipy
 
 # install requirements
 install_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -39,20 +39,16 @@ setup(
     description='Swagger Client for the ESI API for EVE Online',
     long_description=README,
     install_requires=install_requirements,
-    extras_require={
-        ':python_version == "2.7"': ['futures']
-    },
     tests_require=test_requirements,
     test_suite='nose.collector',
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
     ]
 )

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -6,6 +6,7 @@ import memcache
 import redis
 import shutil
 import unittest
+import time
 
 from collections import namedtuple
 
@@ -94,6 +95,12 @@ class TestDictCache(BaseTest):
         self.c.invalidate(self.ex_cpx[0])
         self.assertIsNone(self.c.get(self.ex_cpx[0]))
 
+    def test_dict_cache_clear(self):
+        self.assertEqual(self.c._dict[self.ex_str[0]], self.ex_str[1])
+        self.assertEqual(len(self.c._dict), 3)
+        self.c.clear()
+        self.assertEqual(len(self.c._dict), 0)
+
 
 class TestDummyCache(BaseTest):
     """ DummyCache test class. """
@@ -151,6 +158,22 @@ class TestFileCache(BaseTest):
         self.c.invalidate('key')
         self.assertEqual(self.c.get('key'), None)
 
+    def test_file_cache_expire(self):
+        self.c.set('key', 'bar', expire=1)
+        self.assertEqual(self.c.get('key'), 'bar')
+        time.sleep(1)
+        self.assertEqual(self.c.get('key', None), None)
+
+        self.c.set('key', 'bar', expire=0)
+        self.assertEqual(self.c.get('key'), 'bar')
+        time.sleep(1)
+        self.assertEqual(self.c.get('key', None), 'bar')
+
+        self.c.set('foo', 'baz', expire=None)
+        self.assertEqual(self.c.get('foo'), 'baz')
+        time.sleep(1)
+        self.assertEqual(self.c.get('foo', None), 'baz')
+
 
 class TestMemcachedCache(BaseTest):
     """ Memcached tests """
@@ -196,6 +219,22 @@ class TestMemcachedCache(BaseTest):
         with self.assertRaises(TypeError):
             MemcachedCache(None)
 
+    def test_memcached_expire(self):
+        self.c.set(self.ex_str[0], self.ex_str[1], expire=1)
+        self.assertEqual(self.c.get(self.ex_str[0]), self.ex_str[1])
+        time.sleep(1)
+        self.assertEqual(self.c.get(self.ex_str[0], None), None)
+
+        self.c.set(self.ex_str[0], self.ex_str[1], expire=0)
+        self.assertEqual(self.c.get(self.ex_str[0]), self.ex_str[1])
+        time.sleep(1)
+        self.assertEqual(self.c.get(self.ex_str[0], None), self.ex_str[1])
+
+        self.c.set(self.ex_int[0], self.ex_int[1], expire=None)
+        self.assertEqual(self.c.get(self.ex_int[0]), self.ex_int[1])
+        time.sleep(1)
+        self.assertEqual(self.c.get(self.ex_int[0], None), self.ex_int[1])
+
 
 class TestRedisCache(BaseTest):
     """RedisCache tests"""
@@ -239,3 +278,19 @@ class TestRedisCache(BaseTest):
     def test_redis_invalid_argument(self):
         with self.assertRaises(TypeError):
             RedisCache(None)
+
+    def test_redis_expire(self):
+        self.c.set(self.ex_str[0], self.ex_str[1], expire=1)
+        self.assertEqual(self.c.get(self.ex_str[0]), self.ex_str[1])
+        time.sleep(1)
+        self.assertEqual(self.c.get(self.ex_str[0], None), None)
+
+        self.c.set(self.ex_str[0], self.ex_str[1], expire=0)
+        self.assertEqual(self.c.get(self.ex_str[0]), self.ex_str[1])
+        time.sleep(1)
+        self.assertEqual(self.c.get(self.ex_str[0], None), self.ex_str[1])
+
+        self.c.set(self.ex_int[0], self.ex_int[1], expire=None)
+        self.assertEqual(self.c.get(self.ex_int[0]), self.ex_int[1])
+        time.sleep(1)
+        self.assertEqual(self.c.get(self.ex_int[0], None), self.ex_int[1])


### PR DESCRIPTION
* Fix caches to add timeout everywhere and prevent unlimited growth of cache / need to manual cleanup. (Fix #57) 
* Add `no_etag_body` to `EsiClient.__init__()` ([see docs](https://kyria.github.io/EsiPy/api/esiclient/)) to set the HTTP 304 behavior standard (Fix: #53). This means:
    * `status_code` = 304
    * response body = empty (`res.data = None` and `res.raw = ''`)
* Add catch to `Exception` to prevent crashes from HTTP 504 html response from load balancer (should only happen in this case). (Fix: #49)